### PR TITLE
[FIX] merge configured doktypes with defaults

### DIFF
--- a/Classes/Domain/Repository/MenuRepository.php
+++ b/Classes/Domain/Repository/MenuRepository.php
@@ -102,7 +102,7 @@ class MenuRepository
     {
         $whereClause = '';
         if (!empty($configuration['excludeDoktypes'])) {
-            $excludedDoktypes = array_replace($this->excludedDoktypes, GeneralUtility::intExplode(',', $configuration['excludeDoktypes']));
+            $excludedDoktypes = array_unique(array_merge($this->excludedDoktypes, GeneralUtility::intExplode(',', $configuration['excludeDoktypes'])));
         } else {
             $excludedDoktypes = $this->excludedDoktypes;
         }


### PR DESCRIPTION
array_replace only creates new values on array one by looking at the array-keys - which is useless in this case.

see #11