### PR TITLE
[BUGFIX] Optimize tag usage and cache flushing

### DIFF
--- a/Classes/CacheHelper.php
+++ b/Classes/CacheHelper.php
@@ -46,7 +46,7 @@ class CacheHelper implements SingletonInterface
         try {
             $this->workspaceId = (int)$context->getPropertyFromAspect('workspace', 'id');
         } catch (AspectNotFoundException $e) {
-            
+
         }
     }
 
@@ -96,6 +96,9 @@ class CacheHelper implements SingletonInterface
     /**
      * Fetch all IDs of a tree recursively, in order to tag the cache entries properly.
      *
+     * Only pages which have subpages are included, as the "leave pages" are detected on cache flush.
+     * This is reduces the amount of tags in the cache.
+     *
      * @param array $pages
      * @return int[] a flat array with only the IDs (as integer)
      */
@@ -103,8 +106,8 @@ class CacheHelper implements SingletonInterface
     {
         $pageIds = [];
         foreach ($pages as $page) {
-            $pageIds[] = (int)$page['uid'];
             if (!empty($page['subpages'])) {
+                $pageIds[] = (int)$page['uid'];
                 $pageIds = array_merge($pageIds, $this->getAllPageIdsFromItems($page['subpages']));
             }
         }

--- a/Classes/CacheHelper.php
+++ b/Classes/CacheHelper.php
@@ -97,7 +97,7 @@ class CacheHelper implements SingletonInterface
      * Fetch all IDs of a tree recursively, in order to tag the cache entries properly.
      *
      * Only pages which have subpages are included, as the "leave pages" are detected on cache flush.
-     * This is reduces the amount of tags in the cache.
+     * This reduces the amount of tags in the cache.
      *
      * @param array $pages
      * @return int[] a flat array with only the IDs (as integer)

--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -14,8 +14,6 @@ namespace B13\Menus\Hooks;
 
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
-use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -50,31 +48,13 @@ class DataHandlerHook
             return;
         }
         $pageId = (int)$params['uid_page'];
-        // If the current page has subpages, it can be flushed directly
-        if ($this->hasSubpages($pageId)) {
-            $menuTag = 'menuId_' . $pageId;
-        } else {
-            // Page is a "leave" in the tree, so flush the menu ID of the parent page
-            $parentPageId = $dataHandler->getPID('pages', $pageId);
-            $menuTag = 'menuId_' . $parentPageId;
+        $menuTags = ['menuId_' . $pageId];
+        // Clear caches of the parent page as well (needed when moving records)
+        $parentPageId = $dataHandler->getPID('pages', $pageId);
+        if ($parentPageId > 0) {
+            $menuTags[] = 'menuId_' . $parentPageId;
         }
-        $this->cacheHash->flushByTag($menuTag);
-        $this->cachePages->flushByTag($menuTag);
-    }
-
-    protected function hasSubpages(int $pageId): bool
-    {
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('pages');
-        $queryBuilder->getRestrictions()
-            ->removeAll()
-            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-        $result = $queryBuilder
-            ->select('uid')
-            ->from('pages')
-            ->where($queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($pageId, \PDO::PARAM_INT)))
-            ->setMaxResults(1)
-            ->execute()
-            ->fetch();
-        return !(empty($result));
+        $this->cacheHash->flushByTags($menuTags);
+        $this->cachePages->flushByTags($menuTags);
     }
 }

--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -14,14 +14,15 @@ namespace B13\Menus\Hooks;
 
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- * This is a helper class and a wrapper around "cache_hash".
+ * This hook is triggered before caches for a page get flushed.
  *
- * The pure joy of this class is the get() method, which calculates tags and max lifetime based on the fetched
- * records. If found in cache, fetched directly.
+ * Ideally this should not trigger the cache flush but only allow to add tags.
  */
 class DataHandlerHook
 {
@@ -45,16 +46,35 @@ class DataHandlerHook
 
     public function clearMenuCaches(array $params, DataHandler $dataHandler): void
     {
-        if ($params['table'] !== 'pages' || empty($params['tags'])) {
+        if ($params['table'] !== 'pages' || empty($params['uid_page'])) {
             return;
         }
-        $menuTags = [];
-        foreach ($params['tags'] as $tag => $_) {
-            if (strpos($tag, 'pageId_') === 0) {
-                $menuTags[] = str_replace('pageId_', 'menuId_', $tag);
-            }
+        $pageId = (int)$params['uid_page'];
+        // If the current page has subpages, it can be flushed directly
+        if ($this->hasSubpages($pageId)) {
+            $menuTag = 'menuId_' . $pageId;
+        } else {
+            // Page is a "leave" in the tree, so flush the menu ID of the parent page
+            $parentPageId = $dataHandler->getPID('pages', $pageId);
+            $menuTag = 'menuId_' . $parentPageId;
         }
-        $this->cacheHash->flushByTags($menuTags);
-        $this->cachePages->flushByTags($menuTags);
+        $this->cacheHash->flushByTag($menuTag);
+        $this->cachePages->flushByTag($menuTag);
+    }
+
+    protected function hasSubpages(int $pageId): bool
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('pages');
+        $queryBuilder->getRestrictions()
+            ->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        $result = $queryBuilder
+            ->select('uid')
+            ->from('pages')
+            ->where($queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($pageId, \PDO::PARAM_INT)))
+            ->setMaxResults(1)
+            ->execute()
+            ->fetch();
+        return !(empty($result));
     }
 }


### PR DESCRIPTION
The change
* Does not add tags to a specific "page leave" anymore
* Flushes the caches only for the tag of "menuId_currentPage" of what is flushed
* Checks for "page leaves" on the cache flushing to flush the right "menuId_" tag

This helps to
* avoid having lots of tags in the cache backend anymore
* reduce the amount of "flushByTag"/"flushByTags" calls when flushing the caches