### PR TITLE
[BUGFIX] respect nav_hide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /var/
 /composer.lock
 /.php_cs.cache
+/.env

--- a/Tests/Functional/Domain/Repository/Fixtures/translated_page_with_nav_hide.xml
+++ b/Tests/Functional/Domain/Repository/Fixtures/translated_page_with_nav_hide.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <sys_language>
+        <uid>1</uid>
+        <pid>0</pid>
+        <title>de</title>
+    </sys_language>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+        <title>page-1</title>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <pid>0</pid>
+        <sys_language_uid>1</sys_language_uid>
+        <title>page-1-de</title>
+        <l10n_parent>1</l10n_parent>
+        <nav_hide>1</nav_hide>
+    </pages>
+
+</dataset>

--- a/Tests/Functional/Domain/Repository/MenuRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/MenuRepositoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace B13\Menus\Tests\Functional\Domain\Repository;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "menus" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+
+use B13\Menus\Domain\Repository\MenuRepository;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\LanguageAspect;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+
+class MenuRepositoryTest extends FunctionalTestCase
+{
+
+    /**
+     * @var array
+     */
+    protected $testExtensionsToLoad = [
+        'typo3conf/ext/menus'
+    ];
+
+    /**
+     * @test
+     */
+    public function translatedPageIsNotInMenuIfNavHideIsSet(): void
+    {
+        $this->importDataSet(ORIGINAL_ROOT . 'typo3conf/ext/menus/Tests/Functional/Domain/Repository/Fixtures/translated_page_with_nav_hide.xml');
+        $languageAspect = GeneralUtility::makeInstance(LanguageAspect::class, 1);
+        GeneralUtility::makeInstance(Context::class)->setAspect('language', $languageAspect);
+        $menuRepository = GeneralUtility::makeInstance(MenuRepository::class);
+        $page = $menuRepository->getPage(1, []);
+        self::assertSame([], $page);
+    }
+}


### PR DESCRIPTION
currently nav_hide is only considered in treemenu, when subpages are created
only for default-pages

this patch adds a check for all menu-pages (in all languages)
if nav_hide is set.

Resolves: #30