### PR TITLE
[FEATURE] Add excludePages option to breadcrumbs menu

### DIFF
--- a/Classes/Domain/Repository/MenuRepository.php
+++ b/Classes/Domain/Repository/MenuRepository.php
@@ -49,7 +49,12 @@ class MenuRepository
         $pages = [];
         $languageAspect = $this->context->getAspect('language');
         $excludeDoktypes = $this->getExcludeDoktypes($configuration);
+        $excludedPagesArray = $this->getExcludePages($configuration);
         foreach ($originalRootLine as $pageInRootLine) {
+            // check for excluded page before useless retrieving page record
+            if ($excludedPagesArray && in_array((int)$pageInRootLine['uid'], $excludedPagesArray)) {
+                continue;
+            }
             $page = $this->pageRepository->getPage((int)$pageInRootLine['uid']);
             if (!$this->isPageSuitableForLanguage($page, $languageAspect)) {
                 continue;
@@ -109,6 +114,19 @@ class MenuRepository
             $excludedDoktypes = $this->excludedDoktypes;
         }
         return $excludedDoktypes;
+    }
+
+    /**
+     * @param array $configuration
+     * @return array
+     */
+    protected function getExcludePages(array $configuration): ?array
+    {
+        $excludePages = null;
+        if (!empty($configuration['excludePages'])) {
+            $excludePages = array_unique(GeneralUtility::intExplode(',', $configuration['excludePages']));
+        }
+        return empty($excludePages) ? null : $excludePages;
     }
 
     public function getSubPagesOfPage(int $pageId, int $depth, array $configuration)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The extension ships TypoScript cObjects and TypoScript DataProcessors for Fluid-
 
 ### Common Options for all menus
 
-* excludePages - a list of page IDs (and their subpages if Tree Menu is used) to exclude from the page
+* excludePages - a list of page IDs (and their subpages if Tree Menu or Breadcrumbs is used) to exclude from the page
 * excludeDoktypes - a list of doktypes that are not rendered. BE_USER_SECTIONs are excluded by default. SYS_FOLDERs are queried (for subpages etc) but never rendered.
 
 ### Common options for items
@@ -167,6 +167,7 @@ Usage in Fluid:
 ### Breadcrumb Menu (a.k.a. Rootline Menu)
 
     page.10 = BREADCRUMBS
+    page.10.excludePages = 4,51
     page.10.wrap = <ul> | </ul>
     page.10.renderObj = TEXT
     page.10.renderObj.typolink.parameter.data = field:uid
@@ -177,6 +178,7 @@ Fluid-based solution:
 
     page.10 = FLUIDTEMPLATE
     page.10.dataProcessing.10 = B13\Menus\DataProcessing\BreadcrumbsMenu
+    page.10.dataProcessors.10.excludePages = 4,51
     page.10.dataProcessing.10.as = breadcrumbs
 
 Usage in Fluid:

--- a/Tests/Functional/DataProcessing/BreadcrumbsMenuTest.php
+++ b/Tests/Functional/DataProcessing/BreadcrumbsMenuTest.php
@@ -10,11 +10,9 @@ namespace B13\Menus\Tests\Functional\DataProcessing;
  * of the License, or any later version.
  */
 
-
 use B13\Menus\DataProcessing\BreadcrumbsMenu;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-
 
 class BreadcrumbsMenuTest extends DataProcessingTest
 {
@@ -63,6 +61,19 @@ class BreadcrumbsMenuTest extends DataProcessingTest
                         'isCurrentPage' => false
                     ]
                 ]
+            ],
+            [
+                'tsfe' => ['id' => 2, 'rootLine' => [['uid' => 1], ['uid' => 2]]],
+                'configuration' => ['excludePages' => 1],
+                'expected' => [
+                    [
+                        'uid' => 2,
+                        'hasSubpages' => false,
+                        'level' => 1,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => true
+                    ]
+                ]
             ]
         ];
     }
@@ -79,8 +90,8 @@ class BreadcrumbsMenuTest extends DataProcessingTest
         $breadcrumbsMenuProcessor = GeneralUtility::makeInstance(BreadcrumbsMenu::class);
         $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
         $breadcrumbs = $breadcrumbsMenuProcessor->process($contentObjectRenderer, [], $configuration, []);
-        $this->assertIsArray($breadcrumbs['breadcrumbs']);
+        self::assertIsArray($breadcrumbs['breadcrumbs']);
         $reduced = $this->reduceResults($breadcrumbs['breadcrumbs']);
-        $this->assertSame($expected, $reduced);
+        self::assertSame($expected, $reduced);
     }
 }


### PR DESCRIPTION
Add option for exclude pages from breadcrumbs. See feature request #20.


This PR adds the option excludePages for the TypoScript breadcrumbs and 
the breadcumps dataprocessor.

Added functional test case (dataprocessor), which works.

Unit tests fails, but this is not related to this PR. They fails on 
master already. See #19