### PR TITLE
[FEATURE] Add includeNotInMenu option to all menu types

### DIFF
--- a/Classes/Compiler/LanguageMenuCompiler.php
+++ b/Classes/Compiler/LanguageMenuCompiler.php
@@ -44,7 +44,7 @@ class LanguageMenuCompiler extends AbstractMenuCompiler
                 }
                 $languageAspect = LanguageAspectFactory::createFromSiteLanguage($language);
                 $context->setAspect('language', $languageAspect);
-                $page = $this->menuRepository->getPageInLanguage($targetPage, $context);
+                $page = $this->menuRepository->getPageInLanguage($targetPage, $context, $configuration);
                 if (!empty($page)) {
                     $page['language'] = $language->toArray();
                     if (!empty($page['_PAGES_OVERLAY']) && $page['_PAGES_OVERLAY'] === true) {

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The extension ships TypoScript cObjects and TypoScript DataProcessors for Fluid-
 
 * excludePages - a list of page IDs (and their subpages if Tree Menu or Breadcrumbs is used) to exclude from the page
 * excludeDoktypes - a list of doktypes that are not rendered. BE_USER_SECTIONs are excluded by default. SYS_FOLDERs are queried (for subpages etc) but never rendered.
+* includeNotInMenu - include pages with nav_hide set to 1, instead of ignoring them
 
 ### Common options for items
 
@@ -73,6 +74,8 @@ Pure TypoScript-based solution:
     # the number of levels to fetch from the database (1 if empty)
     page.10.depth = 3
     page.10.excludePages = 4,51
+    # 0: default, 1 to include nav_hide = 1 pages
+    page.10.includeNotInMenu = 0
     page.10.renderObj.level1 = TEXT
     page.10.renderObj.level1.typolink.parameter.data = field:uid
     page.10.renderObj.level1.typolink.ATagParams = class="active"
@@ -86,6 +89,8 @@ Fluid-based solution:
     page.10.dataProcessing.10.entryPoints = 23,13
     page.10.dataProcessing.10.depth = 3
     page.10.dataProcessing.10.excludePages = 4,51
+    # 0: default, 1 to include nav_hide = 1 pages
+    page.10.dataProcessing.10.includeNotInMenu = 0
     page.10.dataProcessing.10.as = mobilemenu
 
 Usage in Fluid:
@@ -113,6 +118,8 @@ Pure TypoScript solution:
 
     page.10 = LANGUAGEMENU
     page.10.excludeLanguages = de,en
+    # 0: default, 1 to include nav_hide = 1 pages
+    page.10.includeNotInMenu = 0
     page.10.wrap = <ul> | </ul>
     page.10.renderObj = TEXT
     page.10.renderObj.typolink.parameter.data = field:uid
@@ -126,6 +133,8 @@ Fluid-based solution:
     page.10 = FLUIDTEMPLATE
     page.10.dataProcessing.10 = B13\Menus\DataProcessing\LanguageMenu
     page.10.dataProcessing.10.excludeLanguages = de,en
+    # 0: default, 1 to include nav_hide = 1 pages
+    page.10.dataProcessing.10.includeNotInMenu = 0
     page.10.dataProcessing.10.as = languageswitcher
 
 Usage in Fluid:
@@ -147,6 +156,8 @@ Pure TypoScript-based solution:
     page.10 = LISTMENU
     # a page ID, rootpageID is used if none given, stdWrap possible
     page.10.pages = 13,14,15
+    # 0: default, 1 to include nav_hide = 1 pages
+    page.10.includeNotInMenu = 0
 
 Fluid-based solution:
 
@@ -154,6 +165,8 @@ Fluid-based solution:
     page.10.dataProcessing.10 = B13\Menus\DataProcessing\ListMenu
     page.10.dataProcessing.10.pages = 13,14,15
     page.10.dataProcessing.10.as = footerlinks
+    # 0: default, 1 to include nav_hide = 1 pages
+    page.10.dataProcessing.10.includeNotInMenu = 0
 
 Usage in Fluid:
 
@@ -168,6 +181,8 @@ Usage in Fluid:
 
     page.10 = BREADCRUMBS
     page.10.excludePages = 4,51
+    # 0: default, 1 to include nav_hide = 1 pages
+    page.10.includeNotInMenu = 0
     page.10.wrap = <ul> | </ul>
     page.10.renderObj = TEXT
     page.10.renderObj.typolink.parameter.data = field:uid
@@ -179,6 +194,8 @@ Fluid-based solution:
     page.10 = FLUIDTEMPLATE
     page.10.dataProcessing.10 = B13\Menus\DataProcessing\BreadcrumbsMenu
     page.10.dataProcessors.10.excludePages = 4,51
+    # 0: default, 1 to include nav_hide = 1 pages
+    page.10.dataProcessing.10.includeNotInMenu = 0
     page.10.dataProcessing.10.as = breadcrumbs
 
 Usage in Fluid:
@@ -199,7 +216,7 @@ If you want to get a menu of the direct siblings of a page, no matter what page 
 		entryPoints.data = page:pid
 		as = listOfJobPages
 	}
-    
+
 By using the `.data` property of the entryPointy attribute we can access each property of the currently build page. And so we can render the siblings of the page.
 
 ## Technical Details

--- a/Tests/Functional/DataProcessing/BreadcrumbsMenuTest.php
+++ b/Tests/Functional/DataProcessing/BreadcrumbsMenuTest.php
@@ -74,6 +74,111 @@ class BreadcrumbsMenuTest extends DataProcessingTest
                         'isCurrentPage' => true
                     ]
                 ]
+            ],
+            [
+                'tsfe' => ['id' => 5, 'rootLine' => [['uid' => 1], ['uid' => 2], ['uid' => 5]]],
+                'configuration' => [],
+                'expected' => [
+                    [
+                        'uid' => 2,
+                        'hasSubpages' => false,
+                        'level' => 2,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 1,
+                        'hasSubpages' => false,
+                        'level' => 1,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => false
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 5, 'rootLine' => [['uid' => 1], ['uid' => 2], ['uid' => 5]]],
+                'configuration' => ['includeNotInMenu' => 1],
+                'expected' => [
+                    [
+                        'uid' => 5,
+                        'hasSubpages' => false,
+                        'level' => 3,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => true
+                    ],
+                    [
+                        'uid' => 2,
+                        'hasSubpages' => false,
+                        'level' => 2,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 1,
+                        'hasSubpages' => false,
+                        'level' => 1,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => false
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 5, 'rootLine' => [['uid' => 1], ['uid' => 2], ['uid' => 5]]],
+                'configuration' => ['includeNotInMenu' => 1, 'excludePages' => '1'],
+                'expected' => [
+                    [
+                        'uid' => 5,
+                        'hasSubpages' => false,
+                        'level' => 2,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => true
+                    ],
+                    [
+                        'uid' => 2,
+                        'hasSubpages' => false,
+                        'level' => 1,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => false
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 5, 'rootLine' => [['uid' => 1], ['uid' => 2], ['uid' => 5]]],
+                'configuration' => ['includeNotInMenu' => 1, 'excludeDoktypes' => 99],
+                'expected' => [
+                    [
+                        'uid' => 5,
+                        'hasSubpages' => false,
+                        'level' => 2,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => true
+                    ],
+                    [
+                        'uid' => 1,
+                        'hasSubpages' => false,
+                        'level' => 1,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => false
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 5, 'rootLine' => [['uid' => 1], ['uid' => 2], ['uid' => 5]]],
+                'configuration' => ['includeNotInMenu' => 1, 'excludeDoktypes' => 99, 'excludePages' => '1'],
+                'expected' => [
+                    [
+                        'uid' => 5,
+                        'hasSubpages' => false,
+                        'level' => 1,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => true
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 5, 'rootLine' => [['uid' => 1], ['uid' => 2], ['uid' => 5]]],
+                'configuration' => ['excludeDoktypes' => 99, 'excludePages' => '1'],
+                'expected' => []
             ]
         ];
     }

--- a/Tests/Functional/DataProcessing/ListMenuProcessorTest.php
+++ b/Tests/Functional/DataProcessing/ListMenuProcessorTest.php
@@ -1,0 +1,388 @@
+<?php
+
+namespace Functional\DataProcessing;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "menus" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use B13\Menus\DataProcessing\ListMenu;
+use B13\Menus\Tests\Functional\DataProcessing\DataProcessingTest;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Site\Entity\NullSite;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+class ListMenuProcessorTest extends DataProcessingTest
+{
+
+    /**
+     * @return array
+     */
+    public function setupDataProvider()
+    {
+        return [
+            [
+                'tsfe' => ['id' => 2, 'rootLine' => [['uid' => 1], ['uid' => 2]]],
+                'configuration' => ['as' => 'my-list', 'pages' => '2,4,6'],
+                'expected' => [
+                    [
+                        'uid' => 2,
+                        'hasSubpages' => false,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => true
+                    ],
+                    [
+                        'uid' => 4,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 4, 'rootLine' => [['uid' => 1], ['uid' => 4]]],
+                'configuration' => ['as' => 'my-list', 'pages' => '2,4,6'],
+                'expected' => [
+                    [
+                        'uid' => 2,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 4,
+                        'hasSubpages' => false,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => true
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 4, 'rootLine' => [['uid' => 1], ['uid' => 4]]],
+                'configuration' => ['as' => 'my-list', 'pages' => '2,4,3,5,6'],
+                'expected' => [
+                    [
+                        'uid' => 2,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 4,
+                        'hasSubpages' => false,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => true
+                    ],
+                    [
+                        'uid' => 3,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 3, 'rootLine' => [['uid' => 1], ['uid' => 2], ['uid' => 3]]],
+                'configuration' => ['as' => 'my-list', 'pages' => '2,4,3,5,6'],
+                'expected' => [
+                    [
+                        'uid' => 2,
+                        'hasSubpages' => false,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 4,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 3,
+                        'hasSubpages' => false,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => true
+                    ]
+                ]
+            ],
+            # tests with includeNotInMenu
+            [
+                'tsfe' => ['id' => 2, 'rootLine' => [['uid' => 1], ['uid' => 2]]],
+                'configuration' => ['as' => 'my-list', 'pages' => '2,4,6', 'includeNotInMenu' => 1,],
+                'expected' => [
+                    [
+                        'uid' => 2,
+                        'hasSubpages' => false,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => true
+                    ],
+                    [
+                        'uid' => 4,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 6,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 4, 'rootLine' => [['uid' => 1], ['uid' => 4]]],
+                'configuration' => ['as' => 'my-list', 'pages' => '2,4,6', 'includeNotInMenu' => 1,],
+                'expected' => [
+                    [
+                        'uid' => 2,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 4,
+                        'hasSubpages' => false,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => true
+                    ],
+                    [
+                        'uid' => 6,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 4, 'rootLine' => [['uid' => 1], ['uid' => 4]]],
+                'configuration' => ['as' => 'my-list', 'pages' => '2,4,3,5,6', 'includeNotInMenu' => 1,],
+                'expected' => [
+                    [
+                        'uid' => 2,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 4,
+                        'hasSubpages' => false,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => true
+                    ],
+                    [
+                        'uid' => 3,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 5,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 6,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 3, 'rootLine' => [['uid' => 1], ['uid' => 2], ['uid' => 3]]],
+                'configuration' => ['as' => 'my-list', 'pages' => '2,4,3,5,6', 'includeNotInMenu' => 1,],
+                'expected' => [
+                    [
+                        'uid' => 2,
+                        'hasSubpages' => false,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 4,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 3,
+                        'hasSubpages' => false,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => true
+                    ],
+                    [
+                        'uid' => 5,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 6,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 5, 'rootLine' => [['uid' => 1], ['uid' => 2], ['uid' => 5]]],
+                'configuration' => ['as' => 'my-list', 'pages' => '2,4,3,5,6', 'includeNotInMenu' => 1,],
+                'expected' => [
+                    [
+                        'uid' => 2,
+                        'hasSubpages' => false,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 4,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 3,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 5,
+                        'hasSubpages' => false,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => true
+                    ],
+                    [
+                        'uid' => 6,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 6, 'rootLine' => [['uid' => 1], ['uid' => 6]]],
+                'configuration' => ['as' => 'my-list', 'pages' => '2,4,3,5,6', 'includeNotInMenu' => 1,],
+                'expected' => [
+                    [
+                        'uid' => 2,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 4,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 3,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 5,
+                        'hasSubpages' => false,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 6,
+                        'hasSubpages' => false,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => true
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider setupDataProvider
+     */
+    public function processTest(array $tsfe, array $configuration, array $expected)
+    {
+        $site = GeneralUtility::makeInstance(NullSite::class);
+        $request = GeneralUtility::makeInstance(ServerRequest::class);
+        $request = $request->withAttribute('site', $site);
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+
+        $GLOBALS['TSFE'] = GeneralUtility::makeInstance(TypoScriptFrontendController::class, null, $site, $site->getLanguageById(0));
+        $GLOBALS['TSFE']->rootLine = $tsfe['rootLine'];
+        $GLOBALS['TSFE']->id = $tsfe['id'];
+
+        $listMenuProcessor = GeneralUtility::makeInstance(ListMenu::class);
+        $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $listMenu = $listMenuProcessor->process($contentObjectRenderer, [], $configuration, []);
+
+        self::assertIsArray($listMenu['my-list']);
+        $this->reduceResultsRecursive($listMenu['my-list']);
+        self::assertSame($expected, $listMenu['my-list']);
+    }
+
+    /**
+     * @return array
+     */
+    public function cacheDataProvider()
+    {
+        return [
+            [
+                'tsfe' => ['id' => 2, 'rootLine' => [['uid' => 1], ['uid' => 2]]],
+                'configuration' => ['as' => 'my-list', 'pages' => '2,4,6'],
+                'expectedTags' => ['menuId_1',],
+            ],
+            [
+                'tsfe' => ['id' => 4, 'rootLine' => [['uid' => 1], ['uid' => 4]]],
+                'configuration' => ['as' => 'my-list', 'pages' => '2,4,6'],
+                'expectedTags' => ['menuId_1',],
+            ],
+            [
+                'tsfe' => ['id' => 4, 'rootLine' => [['uid' => 1], ['uid' => 4]]],
+                'configuration' => ['as' => 'my-list', 'pages' => '2,4,3,5,6'],
+                'expectedTags' => ['menuId_1','menuId_2',],
+            ],
+            [
+                'tsfe' => ['id' => 3, 'rootLine' => [['uid' => 1], ['uid' => 2], ['uid' => 3]]],
+                'configuration' => ['as' => 'my-list', 'pages' => '2,4,3,5,6'],
+                'expectedTags' => ['menuId_1','menuId_2',],
+            ]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider cacheDataProvider
+     */
+    public function menuIdTagsAreAddedToPageCache(array $tsfe, array $configuration, array $expectedTags)
+    {
+        $site = GeneralUtility::makeInstance(NullSite::class);
+        $request = GeneralUtility::makeInstance(ServerRequest::class);
+        $request = $request->withAttribute('site', $site);
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+
+        $GLOBALS['TSFE'] = GeneralUtility::makeInstance(TypoScriptFrontendController::class, null, $site, $site->getLanguageById(0));
+        $GLOBALS['TSFE']->rootLine = $tsfe['rootLine'];
+        $GLOBALS['TSFE']->id = $tsfe['id'];
+
+        $listMenuProcessor = GeneralUtility::makeInstance(ListMenu::class);
+        $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $listMenuProcessor->process($contentObjectRenderer, [], $configuration, []);
+        $pageCacheTags = $GLOBALS['TSFE']->getPageCacheTags();
+
+        self::assertSame(count($expectedTags), count($pageCacheTags));
+        foreach ($expectedTags as $expectedTag) {
+            self::assertTrue(in_array($expectedTag, $pageCacheTags, true));
+        }
+    }
+}

--- a/Tests/Functional/DataProcessing/TreeMenuProcessorTest.php
+++ b/Tests/Functional/DataProcessing/TreeMenuProcessorTest.php
@@ -12,7 +12,6 @@ namespace B13\Menus\Tests\Functional\DataProcessing;
 
 
 use B13\Menus\DataProcessing\TreeMenu;
-use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Site\Entity\NullSite;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -29,7 +28,7 @@ class TreeMenuProcessorTest extends DataProcessingTest
     {
         return [
             [
-                'tsfe' => ['id' => 2, 'rootLine' => [['uid' => 1], ['uid' => 2], ['uid' => 3]]],
+                'tsfe' => ['id' => 2, 'rootLine' => [['uid' => 1], ['uid' => 2]]],
                 'configuration' => ['as' => 'my-tree', 'entryPoints' => 1, 'depth' => 2],
                 'expected' => [
                     [
@@ -43,7 +42,7 @@ class TreeMenuProcessorTest extends DataProcessingTest
                                 'uid' => 3,
                                 'hasSubpages' => false,
                                 'level' => 2,
-                                'isInRootLine' => true,
+                                'isInRootLine' => false,
                                 'isCurrentPage' => false
                             ]
                         ]
@@ -58,7 +57,7 @@ class TreeMenuProcessorTest extends DataProcessingTest
                 ]
             ],
             [
-                'tsfe' => ['id' => 2, 'rootLine' => [['uid' => 1], ['uid' => 2], ['uid' => 3]]],
+                'tsfe' => ['id' => 2, 'rootLine' => [['uid' => 1], ['uid' => 2]]],
                 'configuration' => ['as' => 'my-tree', 'entryPoints' => 1, 'depth' => 0, 'includeRootPages' => true],
                 'expected' => [
                     [
@@ -87,7 +86,7 @@ class TreeMenuProcessorTest extends DataProcessingTest
                 ]
             ],
             [
-                'tsfe' => ['id' => 2, 'rootLine' => [['uid' => 1], ['uid' => 2], ['uid' => 3]]],
+                'tsfe' => ['id' => 2, 'rootLine' => [['uid' => 1], ['uid' => 2]]],
                 'configuration' => ['as' => 'my-tree', 'entryPoints' => 1, 'depth' => 2, 'includeRootPages' => true],
                 'expected' => [
                     [
@@ -108,7 +107,7 @@ class TreeMenuProcessorTest extends DataProcessingTest
                                         'uid' => 3,
                                         'hasSubpages' => false,
                                         'level' => 3,
-                                        'isInRootLine' => true,
+                                        'isInRootLine' => false,
                                         'isCurrentPage' => false
                                     ]
                                 ]
@@ -119,6 +118,271 @@ class TreeMenuProcessorTest extends DataProcessingTest
                                 'level' => 2,
                                 'isInRootLine' => false,
                                 'isCurrentPage' => false
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 5, 'rootLine' => [['uid' => 1], ['uid' => 2],['uid' => 5]]],
+                'configuration' => ['as' => 'my-tree', 'entryPoints' => 1, 'depth' => 2],
+                'expected' => [
+                    [
+                        'uid' => 2,
+                        'hasSubpages' => true,
+                        'level' => 1,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => false,
+                        'subpages' => [
+                            [
+                                'uid' => 3,
+                                'hasSubpages' => false,
+                                'level' => 2,
+                                'isInRootLine' => false,
+                                'isCurrentPage' => false
+                            ]
+                        ]
+                    ],
+                    [
+                        'uid' => 4,
+                        'hasSubpages' => false,
+                        'level' => 1,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ]
+                ]
+            ],
+            # includeNotInMenu option tests
+            [
+                'tsfe' => ['id' => 2, 'rootLine' => [['uid' => 1], ['uid' => 2]]],
+                'configuration' => ['as' => 'my-tree', 'entryPoints' => 1, 'depth' => 2, 'includeNotInMenu' => 1],
+                'expected' => [
+                    [
+                        'uid' => 2,
+                        'hasSubpages' => true,
+                        'level' => 1,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => true,
+                        'subpages' => [
+                            [
+                                'uid' => 3,
+                                'hasSubpages' => false,
+                                'level' => 2,
+                                'isInRootLine' => false,
+                                'isCurrentPage' => false
+                            ],
+                            [
+                                'uid' => 5,
+                                'hasSubpages' => false,
+                                'level' => 2,
+                                'isInRootLine' => false,
+                                'isCurrentPage' => false
+                            ]
+                        ]
+                    ],
+                    [
+                        'uid' => 4,
+                        'hasSubpages' => false,
+                        'level' => 1,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ],
+                    [
+                        'uid' => 6,
+                        'hasSubpages' => false,
+                        'level' => 1,
+                        'isInRootLine' => false,
+                        'isCurrentPage' => false
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 2, 'rootLine' => [['uid' => 1], ['uid' => 2]]],
+                'configuration' => ['as' => 'my-tree', 'entryPoints' => 1, 'depth' => 0, 'includeRootPages' => true, 'includeNotInMenu' => 1],
+                'expected' => [
+                    [
+                        'uid' => 1,
+                        'hasSubpages' => true,
+                        'level' => 1,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => false,
+                        'subpages' => [
+                            [
+                                'uid' => 2,
+                                'hasSubpages' => false,
+                                'level' => 2,
+                                'isInRootLine' => true,
+                                'isCurrentPage' => true
+                            ],
+                            [
+                                'uid' => 4,
+                                'hasSubpages' => false,
+                                'level' => 2,
+                                'isInRootLine' => false,
+                                'isCurrentPage' => false
+                            ],
+                            [
+                                'uid' => 6,
+                                'hasSubpages' => false,
+                                'level' => 2,
+                                'isInRootLine' => false,
+                                'isCurrentPage' => false
+                            ]
+                        ]
+                    ]
+                ],
+            ],
+            [
+                'tsfe' => ['id' => 2, 'rootLine' => [['uid' => 1], ['uid' => 2]]],
+                'configuration' => ['as' => 'my-tree', 'entryPoints' => 1, 'depth' => 2, 'includeRootPages' => true, 'includeNotInMenu' => 1],
+                'expected' => [
+                    [
+                        'uid' => 1,
+                        'hasSubpages' => true,
+                        'level' => 1,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => false,
+                        'subpages' => [
+                            [
+                                'uid' => 2,
+                                'hasSubpages' => true,
+                                'level' => 2,
+                                'isInRootLine' => true,
+                                'isCurrentPage' => true,
+                                'subpages' => [
+                                    [
+                                        'uid' => 3,
+                                        'hasSubpages' => false,
+                                        'level' => 3,
+                                        'isInRootLine' => false,
+                                        'isCurrentPage' => false
+                                    ],
+                                    [
+                                        'uid' => 5,
+                                        'hasSubpages' => false,
+                                        'level' => 3,
+                                        'isInRootLine' => false,
+                                        'isCurrentPage' => false
+                                    ]
+                                ]
+                            ],
+                            [
+                                'uid' => 4,
+                                'hasSubpages' => false,
+                                'level' => 2,
+                                'isInRootLine' => false,
+                                'isCurrentPage' => false
+                            ],
+                            [
+                                'uid' => 6,
+                                'hasSubpages' => false,
+                                'level' => 2,
+                                'isInRootLine' => false,
+                                'isCurrentPage' => false
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 5, 'rootLine' => [['uid' => 1], ['uid' => 2], ['uid' => 5]]],
+                'configuration' => ['as' => 'my-tree', 'entryPoints' => 1, 'depth' => 2, 'includeRootPages' => true, 'includeNotInMenu' => 1],
+                'expected' => [
+                    [
+                        'uid' => 1,
+                        'hasSubpages' => true,
+                        'level' => 1,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => false,
+                        'subpages' => [
+                            [
+                                'uid' => 2,
+                                'hasSubpages' => true,
+                                'level' => 2,
+                                'isInRootLine' => true,
+                                'isCurrentPage' => false,
+                                'subpages' => [
+                                    [
+                                        'uid' => 3,
+                                        'hasSubpages' => false,
+                                        'level' => 3,
+                                        'isInRootLine' => false,
+                                        'isCurrentPage' => false
+                                    ],
+                                    [
+                                        'uid' => 5,
+                                        'hasSubpages' => false,
+                                        'level' => 3,
+                                        'isInRootLine' => true,
+                                        'isCurrentPage' => true
+                                    ]
+                                ]
+                            ],
+                            [
+                                'uid' => 4,
+                                'hasSubpages' => false,
+                                'level' => 2,
+                                'isInRootLine' => false,
+                                'isCurrentPage' => false
+                            ],
+                            [
+                                'uid' => 6,
+                                'hasSubpages' => false,
+                                'level' => 2,
+                                'isInRootLine' => false,
+                                'isCurrentPage' => false
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'tsfe' => ['id' => 6, 'rootLine' => [['uid' => 1], ['uid' => 6]]],
+                'configuration' => ['as' => 'my-tree', 'entryPoints' => 1, 'depth' => 2, 'includeRootPages' => true, 'includeNotInMenu' => 1],
+                'expected' => [
+                    [
+                        'uid' => 1,
+                        'hasSubpages' => true,
+                        'level' => 1,
+                        'isInRootLine' => true,
+                        'isCurrentPage' => false,
+                        'subpages' => [
+                            [
+                                'uid' => 2,
+                                'hasSubpages' => true,
+                                'level' => 2,
+                                'isInRootLine' => false,
+                                'isCurrentPage' => false,
+                                'subpages' => [
+                                    [
+                                        'uid' => 3,
+                                        'hasSubpages' => false,
+                                        'level' => 3,
+                                        'isInRootLine' => false,
+                                        'isCurrentPage' => false
+                                    ],
+                                    [
+                                        'uid' => 5,
+                                        'hasSubpages' => false,
+                                        'level' => 3,
+                                        'isInRootLine' => false,
+                                        'isCurrentPage' => false
+                                    ]
+                                ]
+                            ],
+                            [
+                                'uid' => 4,
+                                'hasSubpages' => false,
+                                'level' => 2,
+                                'isInRootLine' => false,
+                                'isCurrentPage' => false
+                            ],
+                            [
+                                'uid' => 6,
+                                'hasSubpages' => false,
+                                'level' => 2,
+                                'isInRootLine' => true,
+                                'isCurrentPage' => true
                             ]
                         ]
                     ]

--- a/Tests/Functional/Domain/Repository/Fixtures/translated_page_with_nav_hide.xml
+++ b/Tests/Functional/Domain/Repository/Fixtures/translated_page_with_nav_hide.xml
@@ -8,7 +8,10 @@
     <pages>
         <uid>1</uid>
         <pid>0</pid>
+        <sys_language_uid>0</sys_language_uid>
         <title>page-1</title>
+        <l10n_parent>0</l10n_parent>
+        <nav_hide>0</nav_hide>
     </pages>
     <pages>
         <uid>2</uid>
@@ -18,5 +21,4 @@
         <l10n_parent>1</l10n_parent>
         <nav_hide>1</nav_hide>
     </pages>
-
 </dataset>

--- a/Tests/Functional/Domain/Repository/MenuRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/MenuRepositoryTest.php
@@ -35,9 +35,48 @@ class MenuRepositoryTest extends FunctionalTestCase
     {
         $this->importDataSet(ORIGINAL_ROOT . 'typo3conf/ext/menus/Tests/Functional/Domain/Repository/Fixtures/translated_page_with_nav_hide.xml');
         $languageAspect = GeneralUtility::makeInstance(LanguageAspect::class, 1);
-        GeneralUtility::makeInstance(Context::class)->setAspect('language', $languageAspect);
+        $context = GeneralUtility::makeInstance(Context::class);
+        $context->setAspect('language', $languageAspect);
         $menuRepository = GeneralUtility::makeInstance(MenuRepository::class);
         $page = $menuRepository->getPage(1, []);
+        $pageInLanguage = $menuRepository->getPageInLanguage(1, $context, []);
         self::assertSame([], $page);
+        self::assertSame([], $pageInLanguage);
+    }
+
+    /**
+     * @test
+     */
+    public function translatedPageIsInMenuIfNavHideAndIgnoreNavHideIsSet(): void
+    {
+        $this->importDataSet(ORIGINAL_ROOT . 'typo3conf/ext/menus/Tests/Functional/Domain/Repository/Fixtures/translated_page_with_nav_hide.xml');
+        $languageAspect = GeneralUtility::makeInstance(LanguageAspect::class, 1);
+        $context = GeneralUtility::makeInstance(Context::class);
+        $context->setAspect('language', $languageAspect);
+        $menuRepository = GeneralUtility::makeInstance(MenuRepository::class);
+        $page = $menuRepository->getPage(1, ['includeNotInMenu' => 1]);
+        $pageInLanguage = $menuRepository->getPageInLanguage(1, $context, ['includeNotInMenu' => 1]);
+        $page = $this->reduceResults($page);
+        $pageInLanguage = $this->reduceResults($pageInLanguage);
+
+        $expectedPage = [
+            'uid' => 1,
+            'pid' => 0,
+            'sys_language_uid' => 1,
+            'l10n_parent' => 1,
+            'nav_hide' => 1
+        ];
+        self::assertSame($expectedPage, $page);
+        self::assertSame($expectedPage, $pageInLanguage);
+    }
+
+    /**
+     * @param array $results
+     * @return array
+     */
+    protected function reduceResults(array $result): array
+    {
+        $keys = ['uid', 'pid', 'sys_language_uid', 'l10n_parent', 'nav_hide'];
+        return array_intersect_key($result, array_flip($keys));
     }
 }

--- a/Tests/Functional/Fixtures/pages.xml
+++ b/Tests/Functional/Fixtures/pages.xml
@@ -2,10 +2,12 @@
 <dataset>
 
     <!--
-    * page-1
-    ** page 2
-    *** page 3
-    ** page 4
+    * page-1 (nav_hide = 0)
+    ** page 2 (nav_hide = 0)
+    *** page 3 (nav_hide = 0)
+    *** page 5 (nav_hide = 1)
+    ** page 4 (nav_hide = 0)
+    ** page 6 (nav_hide = 1)
     -->
 
     <pages>
@@ -13,6 +15,7 @@
         <pid>0</pid>
         <title>page-1</title>
         <slug>/page-1</slug>
+        <nav_hide>0</nav_hide>
     </pages>
     <pages>
         <uid>2</uid>
@@ -20,17 +23,34 @@
         <doktype>99</doktype>
         <title>page-2</title>
         <slug>/page-1/page-2</slug>
+        <nav_hide>0</nav_hide>
     </pages>
     <pages>
         <uid>3</uid>
         <pid>2</pid>
         <title>page-3</title>
         <slug>/page-1/page-2/page-3</slug>
+        <nav_hide>0</nav_hide>
     </pages>
     <pages>
         <uid>4</uid>
         <pid>1</pid>
         <title>page-4</title>
         <slug>/page-1/page-4</slug>
+        <nav_hide>0</nav_hide>
+    </pages>
+    <pages>
+        <uid>5</uid>
+        <pid>2</pid>
+        <title>page-5</title>
+        <slug>/page-1/page-2/page-5</slug>
+        <nav_hide>1</nav_hide>
+    </pages>
+    <pages>
+        <uid>6</uid>
+        <pid>1</pid>
+        <title>page-6</title>
+        <slug>/page-1/page-6</slug>
+        <nav_hide>1</nav_hide>
     </pages>
 </dataset>


### PR DESCRIPTION
Resolves #50

Add an option to all menu types to ignore the excluding
of pages with nav_hide = 1, if use cases needs this.

- ListMenu
- TreeMenu
- LanguageMenu
- BreadcrumbMenu

The default remains to exclude them, to be non breaking to
the current state of menus behaviour.

Functional pages fixture was extended with pages with
nav_hide = 1 set (and nav_hide = 0 for already existing ones)

Existing functional tests were extended to tests menu building
with pages with nav_hide = 1, with and without includeNotInMenu set.

Additional functionl tests for ListMenu was added, because there
where no functional tests until now.

ListMenu cacheTags tests were added as they work now.