### PR TITLE
[BUGFIX] Ensure page array is available

### DIFF
--- a/Classes/Domain/Repository/MenuRepository.php
+++ b/Classes/Domain/Repository/MenuRepository.php
@@ -182,6 +182,9 @@ class MenuRepository
 
     protected function isPageIncludable(array $page, array $configuration): bool
     {
+        if ($page === []) {
+            return false;
+        }
         return $this->getIncludeNotInMenu($configuration) || (int)$page['nav_hide'] !== 1;
     }
 


### PR DESCRIPTION
If page is deleted (and therefore the $page array is empty) return false instead of accessing the non-existing array. 

Fixes #74 