### PR TITLE
[TASK] Make page fields to select configurable via configuration for …

### DIFF
--- a/Classes/Domain/Repository/MenuRepository.php
+++ b/Classes/Domain/Repository/MenuRepository.php
@@ -105,6 +105,21 @@ class MenuRepository
         return $page;
     }
 
+    protected function getPageFields(array $configuration): string
+    {
+        if (!empty($configuration['pageFields'])) {
+            $items = GeneralUtility::trimExplode(',', $configuration['pageFields'], true);
+            // just make sure if we have a field list to not have "*" included
+            if (count($items) > 1 && ($key = array_search('*', $items)) !== false) {
+                unset($items[$key]);
+            }
+            $pageFields = GeneralUtility::uniqueList(implode(',', $items));
+        } else {
+            $pageFields = '*';
+        }
+        return $pageFields;
+    }
+
     protected function getExcludeDoktypes(array $configuration): array
     {
         if (!empty($configuration['excludeDoktypes'])) {
@@ -137,10 +152,11 @@ class MenuRepository
             $excludedPagesArray = GeneralUtility::intExplode(',', (string)$configuration['excludePages']);
             $whereClause .= ' AND uid NOT IN (' . implode(',', $excludedPagesArray) . ')';
         }
+        $pageFields = $this->getPageFields($configuration);
         $excludedDoktypes = $this->getExcludeDoktypes($configuration);
         $pageTree = $this->pageRepository->getMenu(
             $pageId,
-            '*',
+            $pageFields,
             'sorting',
             'AND doktype NOT IN (' . implode(',', $excludedDoktypes) . ') ' . $whereClause,
             false

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Pure TypoScript-based solution:
     page.10.excludePages = 4,51
     # 0: default, 1 to include nav_hide = 1 pages
     page.10.includeNotInMenu = 0
+    # if pageFields are not set, we take "*" from pages, but you can define
+    page.10.pageFields = uid,pid,title,slug
     page.10.renderObj.level0 = TEXT
     page.10.renderObj.level0.typolink.parameter.data = field:uid
     page.10.renderObj.level0.typolink.ATagParams = class="active"
@@ -91,6 +93,7 @@ Fluid-based solution:
     page.10.dataProcessing.10.entryPoints = 23,13
     page.10.dataProcessing.10.depth = 3
     page.10.dataProcessing.10.excludePages = 4,51
+    page.10.dataProcessing.10.pageFields = uid,pid,title,slug
     # 0: default, 1 to include nav_hide = 1 pages
     page.10.dataProcessing.10.includeNotInMenu = 0
     page.10.dataProcessing.10.as = mobilemenu


### PR DESCRIPTION
…TreeMenu

Add the possibility to provide a list of page fields to select for the TreeMenu by setting e.g.:
pageFields = uid,pid,title,slug

- If the property is not set, it uses "*" for the select fields.
- If "*" is also in the list, it gets deleted from the list
- empty values wil be removed, so a type like "uid,,pid,title" is covered

The TreeMenu processor is a fast way to use it e.g. for an RESTful API. In order to create simpler API schemas it´s easier to define which fields are needed from pages. So the schema does not need to provide all ~100 fields if 5-6 are enough.

The change does not touch that nav_title, hasSubpages and subpages will be populated.