### PR TITLE
[BUGFIX] do not set ContentObjectRenderer in ContentObjects for v12

### DIFF
--- a/Build/phpstan10.neon
+++ b/Build/phpstan10.neon
@@ -7,8 +7,5 @@ parameters:
 
   ignoreErrors:
     -
-      message: '#Call to an undefined method B13\\Menus\\ContentObject\\.*ContentObject::setContentObjectRenderer\(\).#'
-      path: %currentWorkingDirectory%/Classes/ContentObject/*
-    -
       message: '#Property TYPO3\\CMS\\Frontend\\Controller\\TypoScriptFrontendController::\$id \(string\) does not accept int#'
       path: %currentWorkingDirectory%/Tests/Functional/Compiler/LanguageMenuCompilerTest.php

--- a/Classes/ContentObject/BreadcrumbsContentObject.php
+++ b/Classes/ContentObject/BreadcrumbsContentObject.php
@@ -29,8 +29,6 @@ class BreadcrumbsContentObject extends AbstractContentObject
     {
         if ((GeneralUtility::makeInstance(Typo3Version::class))->getMajorVersion() < 12) {
             parent::__construct($cObj);
-        } else {
-            $this->setContentObjectRenderer($cObj);
         }
         $this->menuRepository = (GeneralUtility::makeInstance(ContentObjectServiceContainer::class))->getMenuRepository();
     }

--- a/Classes/ContentObject/LanguageMenuContentObject.php
+++ b/Classes/ContentObject/LanguageMenuContentObject.php
@@ -30,8 +30,6 @@ class LanguageMenuContentObject extends AbstractContentObject
     {
         if ((GeneralUtility::makeInstance(Typo3Version::class))->getMajorVersion() < 12) {
             parent::__construct($cObj);
-        } else {
-            $this->setContentObjectRenderer($cObj);
         }
         $this->languageMenuCompiler = (GeneralUtility::makeInstance(ContentObjectServiceContainer::class))->getLanguageMenuCompiler();
     }

--- a/Classes/ContentObject/ListMenuContentObject.php
+++ b/Classes/ContentObject/ListMenuContentObject.php
@@ -29,8 +29,6 @@ class ListMenuContentObject extends AbstractContentObject
     {
         if ((GeneralUtility::makeInstance(Typo3Version::class))->getMajorVersion() < 12) {
             parent::__construct($cObj);
-        } else {
-            $this->setContentObjectRenderer($cObj);
         }
         $this->listMenuCompiler = (GeneralUtility::makeInstance(ContentObjectServiceContainer::class))->getListMenuCompiler();
     }

--- a/Classes/ContentObject/TreeMenuContentObject.php
+++ b/Classes/ContentObject/TreeMenuContentObject.php
@@ -29,8 +29,6 @@ class TreeMenuContentObject extends AbstractContentObject
     {
         if ((GeneralUtility::makeInstance(Typo3Version::class))->getMajorVersion() < 12) {
             parent::__construct($cObj);
-        } else {
-            $this->setContentObjectRenderer($cObj);
         }
         $this->treeMenuCompiler = (GeneralUtility::makeInstance(ContentObjectServiceContainer::class))->getTreeMenuCompiler();
     }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "typo3/cms-install": "^11.5",
     "typo3/coding-standards": "^0.5",
     "typo3/tailor": "^1.0",
-    "typo3/testing-framework": "^7"
+    "typo3/testing-framework": "7.0.2"
   },
   "config": {
     "vendor-dir": ".Build/vendor",


### PR DESCRIPTION
also use testing-framework 7.0.2, because 7.0.3 breaks cache tests.