### PR TITLE
[BUGFIX] use current prefix for language menu cache identifier

### DIFF
--- a/Classes/Compiler/LanguageMenuCompiler.php
+++ b/Classes/Compiler/LanguageMenuCompiler.php
@@ -23,7 +23,7 @@ class LanguageMenuCompiler extends AbstractMenuCompiler
      */
     public function compile(ContentObjectRenderer $contentObjectRenderer, array $configuration): array
     {
-        $cacheIdentifier = $this->generateCacheIdentifierForMenu('list', $configuration);
+        $cacheIdentifier = $this->generateCacheIdentifierForMenu('language', $configuration);
 
         $excludedLanguages = $contentObjectRenderer->stdWrap($configuration['excludeLanguages'] ?? '', $configuration['excludeLanguages.'] ?? []);
         $excludedLanguages = GeneralUtility::trimExplode(',', $excludedLanguages, true);


### PR DESCRIPTION
Fixes: #87