### PR TITLE
[FIX] Fixed warning(s) in PHP 8.4

### DIFF
--- a/Classes/PageStateMarker.php
+++ b/Classes/PageStateMarker.php
@@ -27,7 +27,7 @@ class PageStateMarker
         self::markStates($page, $level);
     }
 
-    public static function markStates(array &$page, int $level = null): void
+    public static function markStates(array &$page, ?int $level = null): void
     {
         if ($level !== null) {
             $page['level'] = $level;


### PR DESCRIPTION
Hello there,

first of all, many thanks for the development and maintaining of that great extension.

Here is a tiny fix for PHP 8.4 in `Classes/PageStateMarker.php`.