### PR TITLE
[TASK] Simplify isPageInCurrentRootLine check

### DIFF
--- a/Classes/PageStateMarker.php
+++ b/Classes/PageStateMarker.php
@@ -46,12 +46,8 @@ class PageStateMarker
         if (!is_array($GLOBALS['TSFE']->rootLine)) {
             return false;
         }
-        foreach ($GLOBALS['TSFE']->rootLine as $pageInRootLine) {
-            if ((int)$pageInRootLine['uid'] === $pageId) {
-                return true;
-            }
-        }
-        return false;
+
+        return in_array($pageId, array_column($GLOBALS['TSFE']->rootLine, 'uid'));
     }
 
     private static function isCurrentPage(int $pageId): bool


### PR DESCRIPTION
Instead of using a loop, plucking the uids from the rootline is easier to read, I think.